### PR TITLE
initial api implementation

### DIFF
--- a/database.go
+++ b/database.go
@@ -9,10 +9,10 @@ import (
 )
 
 type HopsAgg struct {
-	source      string
-	destination string
-	count       int
-	avg_latency float32
+	Source_ip   string
+	Dest_ip     string
+	Count       int
+	Avg_latency float32
 }
 
 type DBErrors string

--- a/main.go
+++ b/main.go
@@ -31,6 +31,8 @@ type TraceResult struct {
 
 var conn *pgxpool.Pool
 
+const apiPrefix = "/api/v1/"
+
 func getHandle() *pcap.Handle {
 	if os.Getenv("TRACE_ROUTER_LIVE") != "1" {
 		if handle, err := pcap.OpenOffline(os.Getenv("TRACE_ROUTER_INPUT_FILE")); err != nil {
@@ -114,7 +116,7 @@ func main() {
 		handlePacket(packet, &wg, results)
 	}
 
-	http.HandleFunc("/getaggs", HttpGetAggs)
+	http.HandleFunc(apiPrefix+"aggs/", HttpGetAggs)
 	http.ListenAndServe(":8080", nil)
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log/slog"
+	"net/http"
 	"os"
 	"os/exec"
 	"strconv"
@@ -112,6 +113,10 @@ func main() {
 	for packet := range packetSource.Packets() {
 		handlePacket(packet, &wg, results)
 	}
+
+	http.HandleFunc("/getaggs", HttpGetAggs)
+	http.ListenAndServe(":8080", nil)
+
 	go func() {
 		wg.Wait()
 		close(results)

--- a/main.go
+++ b/main.go
@@ -117,6 +117,9 @@ func main() {
 	}
 
 	http.HandleFunc(apiPrefix+"aggs/", HttpGetAggs)
+	http.HandleFunc(apiPrefix+"nodes/", HttpGetNodes)
+	http.HandleFunc(apiPrefix+"aggs", HttpGetAggs)
+	http.HandleFunc(apiPrefix+"nodes", HttpGetNodes)
 	http.ListenAndServe(":8080", nil)
 
 	go func() {

--- a/nodes.go
+++ b/nodes.go
@@ -1,0 +1,20 @@
+package main
+
+type NodeList map[string]int
+
+func GetUniqueNodes(aggs []HopsAgg) NodeList {
+	uniques := make(NodeList)
+	for _, agg := range aggs {
+		incrementNodeList(uniques, agg.Source_ip)
+		incrementNodeList(uniques, agg.Dest_ip)
+	}
+	return uniques
+}
+
+func incrementNodeList(nodeList NodeList, ip string) {
+	if count, ok := nodeList[ip]; ok {
+		nodeList[ip] = count + 1
+	} else {
+		nodeList[ip] = 1
+	}
+}

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -21,10 +22,29 @@ func HttpGetAggs(w http.ResponseWriter, req *http.Request) {
 	sort.Slice(hops[:], func(i, j int) bool {
 		return hops[i].Count > hops[j].Count
 	})
-	for _, agg := range hops {
-		if agg.Source_ip != "localhost" {
-			fmt.Fprintf(w, "source = %s, destination = %s, latency = %f, count = %d \n", agg.Source_ip, agg.Dest_ip, agg.Avg_latency, agg.Count)
-		}
+	out, err := json.Marshal(hops)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "error retrieving hops")
+		return
 	}
+	w.Write(out)
 
+}
+
+func HttpGetNodes(w http.ResponseWriter, req *http.Request) {
+	hops, err := GetAggs(conn)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "error retrieving hops")
+		return
+	}
+	nodeList := GetUniqueNodes(hops)
+	out, err := json.Marshal(nodeList)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "error retrieving hops")
+		return
+	}
+	w.Write(out)
 }

--- a/server.go
+++ b/server.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+)
+
+func HttpGetAggs(w http.ResponseWriter, req *http.Request) {
+	hops, err := GetAggs(conn)
+	if req.Method != http.MethodGet {
+		slog.Info("tried to use method other than GET on getAggs")
+		return
+	}
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "error retrieving hops")
+		return
+	}
+	sort.Slice(hops[:], func(i, j int) bool {
+		return hops[i].Count > hops[j].Count
+	})
+	for _, agg := range hops {
+		if agg.Source_ip != "localhost" {
+			fmt.Fprintf(w, "source = %s, destination = %s, latency = %f, count = %d \n", agg.Source_ip, agg.Dest_ip, agg.Avg_latency, agg.Count)
+		}
+	}
+
+}


### PR DESCRIPTION
This pull request adds a basic HTTP API to expose aggregate hop and node data, introduces new handlers for these endpoints, and refactors data structures for consistency. The main changes are grouped into API additions, handler implementations, and data structure improvements.

**API Additions:**

* Added HTTP endpoints `/api/v1/aggs` and `/api/v1/nodes` (with and without trailing slash) to serve hop and node data via the new handlers. (`main.go`, [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R118-R124) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R34-R35)

**Handler Implementations:**

* Created `server.go` with `HttpGetAggs` and `HttpGetNodes` handlers to serve JSON responses for aggregated hops and unique nodes. These handlers retrieve data, handle errors, marshal results to JSON, and sort hop aggregates by count. (`server.go`, [server.goR1-R50](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R1-R50))

**Data Structure Improvements:**

* Refactored `HopsAgg` struct fields to use exported (capitalized) names for JSON marshaling compatibility and clarity. (`database.go`, [database.goL12-R15](diffhunk://#diff-3a959176e85691e2f895b56153bc13c863f1e95acc0476a53affd12ad7fb1be7L12-R15))
* Added `nodes.go` with a `NodeList` type and helper functions to compute unique nodes from hop aggregates. (`nodes.go`, [nodes.goR1-R20](diffhunk://#diff-5bc2d8471b75bfdf044ca005bc151f75b27c820ab857ef639ffe1124405c3c47R1-R20))

**Other:**

* Imported `net/http` in `main.go` to support the new HTTP server. (`main.go`, [main.goR5](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R5))